### PR TITLE
Merge in "add StochasticStellarPop particle type" from the quokka repo

### DIFF
--- a/.devcontainer/gcc-container/Dockerfile
+++ b/.devcontainer/gcc-container/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/devcontainers/cpp:ubuntu-24.04@sha256:6493de2f97b96f46c61cedf3f31361c754337db912fd1fd5fc7660b331208df8
+FROM mcr.microsoft.com/devcontainers/cpp:ubuntu-24.04@sha256:53f5af4877aaf4c1ee3310f21e0df2ecf0ad6e776910ab3a376f60f2b304a039
 
 RUN apt-get --yes -qq update \
  && apt-get --yes -qq upgrade \

--- a/.devcontainer/rocm-container/Dockerfile
+++ b/.devcontainer/rocm-container/Dockerfile
@@ -1,0 +1,62 @@
+# Use the AMD ROCm image as the base image
+FROM rocm/dev-ubuntu-24.04@sha256:708bbb9e2031a81e949a0847f0655c4fb1a790f8ac7cd0031116f56b04ada7d5
+
+# Set environment variables for CMake
+ENV hip_DIR=/opt/rocm/lib/cmake/hip
+ENV rocrand_DIR=/opt/rocm-6.3.4/lib/cmake/rocrand
+ENV hiprand_DIR=/opt/rocm-6.3.4/lib/cmake/hiprand
+ENV rocprim_DIR=/opt/rocm-6.3.4/lib/cmake/rocprim
+ENV rocsparse_DIR=/opt/rocm-6.3.4/lib/cmake/rocsparse
+ENV AMREX_AMD_ARCH=gfx908
+ENV CC=hipcc
+ENV CXX=hipcc
+
+# Update package lists and install necessary dependencies
+RUN apt-get update -qq && apt-get upgrade -y -qq && \
+    apt-get install -y -qq --no-install-recommends \
+    rocrand-dev hiprand-dev rocprim-dev rocsparse-dev \
+    build-essential wget curl git ninja-build gcc g++ \
+    python3-dev python3-numpy python3-matplotlib python3-pip \
+    libhdf5-dev libopenmpi-dev && \
+    apt-get --yes -qq clean && \
+    rm -rf /var/lib/apt/lists/*
+
+# Install Clang 19.x
+RUN mkdir -m 0755 -p /etc/apt/keyrings/ && \
+ curl -fsSL https://apt.llvm.org/llvm-snapshot.gpg.key | gpg --dearmor -o /etc/apt/keyrings/llvm-snapshot.gpg.key && \
+ echo "deb [signed-by=/etc/apt/keyrings/llvm-snapshot.gpg.key] http://apt.llvm.org/noble/ llvm-toolchain-noble-19 main" | tee /etc/apt/sources.list.d/llvm.list > /dev/null
+
+RUN apt-get clean && apt-get update -y && \
+ apt-get install -y --no-install-recommends clang-19 llvm-19 libomp-19-dev libclang-rt-19-dev clangd-19 && \
+ rm -rf /var/lib/apt/lists/*
+
+# Create symlink for clangd
+RUN ln -s /usr/bin/clangd-19 /usr/bin/clangd
+
+# Install the latest version of CMake
+RUN test -f /usr/share/doc/kitware-archive-keyring/copyright || wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | gpg --dearmor - | tee /usr/share/keyrings/kitware-archive-keyring.gpg >/dev/null && \
+    echo 'deb [signed-by=/usr/share/keyrings/kitware-archive-keyring.gpg] https://apt.kitware.com/ubuntu/ noble main' | tee /etc/apt/sources.list.d/kitware.list >/dev/null
+
+RUN apt-get clean && apt-get update -y && \
+    apt-get install -y --no-install-recommends cmake && \
+    rm -rf /var/lib/apt/lists/*
+
+# Install blosc2 (needed for ADIOS2)
+RUN pip3 install blosc2 --break-system-packages
+
+# Install ADIOS2 (needed for OpenPMD)
+RUN mkdir -p /tmp/build-adios2 && cd /tmp/build-adios2 && \
+    wget -q https://github.com/ornladios/ADIOS2/archive/refs/tags/v2.10.1.tar.gz && \
+    tar xzf v2.10.1.tar.gz && \
+    mkdir adios2-build && cd adios2-build && \
+    cmake ../ADIOS2-2.10.1 -DADIOS2_USE_Blosc2=ON -DADIOS2_USE_Fortran=OFF && \
+    make -j$(nproc) && make install && \
+    cd / && \
+    rm -rf /tmp/build-adios2
+
+# Set the working directory and user
+WORKDIR /home/ubuntu
+USER ubuntu
+
+# Set the default command to bash
+CMD [ "/bin/bash" ]

--- a/.devcontainer/rocm-container/devcontainer.json
+++ b/.devcontainer/rocm-container/devcontainer.json
@@ -1,0 +1,31 @@
+// devcontainer.json
+    {
+      "name": "Quokka ROCm Dev Container",
+      // (NOTE: using the cloud image is temporarily disabled, since it doesn't exist yet)
+      // "image": "ghcr.io/quokka-astro/quokka:development",
+      "build": {
+        // Path is relative to the devcontainer.json file.
+        "dockerfile": "Dockerfile"
+      },
+      "hostRequirements": {
+        "cpus": 4
+      },
+      "customizations": {
+        "vscode": {
+          "settings": {},
+          "extensions": [
+            // disabled, since it interferes with clangd
+            "-ms-vscode.cpptools",
+            "llvm-vs-code-extensions.vscode-clangd",
+            "github.vscode-pull-request-github",
+            "ms-vscode.live-server",
+            "ms-azuretools.vscode-docker"
+          ]
+        }
+      },
+      "remoteUser": "ubuntu",
+      // we need to manually checkout the submodules,
+      // but VSCode may try to configure CMake before they are fully checked-out.
+      // workaround TBD
+      "postCreateCommand": "git submodule update --init"
+    }

--- a/.github/workflows/checkpoint-restart.yml
+++ b/.github/workflows/checkpoint-restart.yml
@@ -61,7 +61,7 @@ jobs:
 
     - name: Upload output
       if: always()
-      uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
       with:
         name: checkpoint-restart-results
         path: ${{github.workspace}}/tests

--- a/.github/workflows/cmake-macos.yml
+++ b/.github/workflows/cmake-macos.yml
@@ -78,7 +78,7 @@ jobs:
 
     - name: Upload test output
       if: always()
-      uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
       with:
         name: test-results
         path: ${{github.workspace}}/tests

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -66,7 +66,7 @@ jobs:
 
     - name: Upload test output
       if: always()
-      uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
       with:
         name: test-results
         path: ${{github.workspace}}/tests

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -47,7 +47,7 @@ jobs:
 
       - name: Set Up Cache
         if: ${{ matrix.language == 'cpp' }}
-        uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf # v4.2.2
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
         with:
           path: ~/.cache/ccache
           key: ccache-${{ github.workflow }}-${{ github.job }}-git-${{ github.sha }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -107,7 +107,7 @@ jobs:
           PR_NUMBER: ${{ github.event.number }}
         run: |
           echo $PR_NUMBER > pr_number.txt
-      - uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: pr_number
           path: pr_number.txt

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -64,14 +64,14 @@ jobs:
               -DCMAKE_CXX_COMPILER="/usr/local/bin/g++"
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@6bb031afdd8eb862ea3fc1848194185e076637e5 # v3.28.11
+        uses: github/codeql-action/init@5f8171a638ada777af81d42b55959a643bb29017 # v3.28.12
         with:
           languages: ${{ matrix.language }}
           queries: +security-and-quality
           config-file: ./.github/workflows/codeql/codeql-config.yml
 
       - name: Build (py)
-        uses: github/codeql-action/autobuild@6bb031afdd8eb862ea3fc1848194185e076637e5 # v3.28.11
+        uses: github/codeql-action/autobuild@5f8171a638ada777af81d42b55959a643bb29017 # v3.28.12
         if: ${{ matrix.language == 'python' }}
 
       - name: Build (C++)
@@ -94,7 +94,7 @@ jobs:
           make -j 4
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@6bb031afdd8eb862ea3fc1848194185e076637e5 # v3.28.11
+        uses: github/codeql-action/analyze@5f8171a638ada777af81d42b55959a643bb29017 # v3.28.12
         with:
           category: "/language:${{ matrix.language }}"
 

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -27,7 +27,7 @@ jobs:
           python-version: '3.10'
 
       - name: Cache pip
-        uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf # v4.2.2
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
         with:
           # this path is specific to Ubuntu
           path: ~/.cache/pip

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -57,7 +57,7 @@ jobs:
           INPUT_PATH: ./docs/site
 
       - name: Upload artifact
-        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: 'github-pages'
           path: ${{ runner.temp }}/artifact.tar

--- a/.github/workflows/hip.yml
+++ b/.github/workflows/hip.yml
@@ -31,7 +31,7 @@ jobs:
     - name: Python and HDF5 dependencies
       run: sudo apt-get update && sudo apt-get install python3-dev python3-numpy python3-matplotlib python3-pip libhdf5-mpi-dev
     - name: Set Up Cache
-      uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf # v4.2.2
+      uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
       with:
         path: ~/.cache/ccache
         key: ccache-${{ github.workflow }}-${{ github.job }}-git-${{ github.sha }}

--- a/.github/workflows/intel.yml
+++ b/.github/workflows/intel.yml
@@ -69,7 +69,7 @@ jobs:
       
     - name: Upload test output
       if: always()
-      uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
       with:
         name: test-results
         path: ${{github.workspace}}/tests
@@ -83,7 +83,7 @@ jobs:
           PR_NUMBER: ${{ github.event.number }}
         run: |
           echo $PR_NUMBER > pr_number.txt
-      - uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: pr_number
           path: pr_number.txt

--- a/.github/workflows/intel.yml
+++ b/.github/workflows/intel.yml
@@ -31,7 +31,7 @@ jobs:
         .github/workflows/dependencies/dependencies_ccache.sh
         
     - name: Set Up Cache
-      uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf # v4.2.2
+      uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
       with:
         path: ~/.cache/ccache
         key: ccache-${{ github.workflow }}-${{ github.job }}-git-${{ github.sha }}

--- a/.github/workflows/openpmd.yml
+++ b/.github/workflows/openpmd.yml
@@ -57,7 +57,7 @@ jobs:
 
     - name: Upload test output
       if: always()
-      uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
       with:
         name: test-results
         path: ${{github.workspace}}/tests

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -68,6 +68,6 @@ jobs:
       # Upload the results to GitHub's code scanning dashboard (optional).
       # Commenting out will disable upload of results to your repo's Code Scanning dashboard
       - name: "Upload to code-scanning"
-        uses: github/codeql-action/upload-sarif@6bb031afdd8eb862ea3fc1848194185e076637e5 # v3.28.11
+        uses: github/codeql-action/upload-sarif@5f8171a638ada777af81d42b55959a643bb29017 # v3.28.12
         with:
           sarif_file: results.sarif

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -59,7 +59,7 @@ jobs:
       # Upload the results as artifacts (optional). Commenting out will disable uploads of run results in SARIF
       # format to the repository Actions tab.
       - name: "Upload artifact"
-        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: SARIF file
           path: results.sarif

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,7 +12,7 @@ repos:
     -   id: check-symlinks
     -   id: mixed-line-ending
 -   repo: https://github.com/pre-commit/mirrors-clang-format
-    rev: v19.1.7
+    rev: v20.1.0
     hooks:
     -   id: clang-format
 ci:

--- a/scripts/delta_ai.profile
+++ b/scripts/delta_ai.profile
@@ -1,0 +1,31 @@
+module load nvidia
+module unload cray-mpich
+export MODULEPATH="/opt/cray/pe/lmod/modulefiles/comnet/nvidia/23.11/ofi/1.0:$MODULEPATH"
+module load cray-mpich
+module load craype-accel-nvidia90 
+
+# hdf5
+module load cray-hdf5
+
+# cmake
+module load cmake/3.30.2
+
+# python
+module load cray-python/3.11.7
+
+# emacs (optional)
+module load emacs/29.3
+
+# GPU-aware MPI
+export MPICH_GPU_SUPPORT_ENABLED=1
+export CRAY_ACCEL_TARGET=nvidia90
+
+# optimize CUDA compilation for Grace-Hopper
+export AMREX_CUDA_ARCH=9.0
+
+# compiler environment hints
+export CC=cc
+export CXX=CC
+export FC=ftn
+export CUDACXX=$(which nvcc)
+export CUDAHOSTCXX=CC

--- a/scripts/dtai-1node.submit
+++ b/scripts/dtai-1node.submit
@@ -1,0 +1,16 @@
+#!/bin/bash
+#SBATCH --mem=0
+#SBATCH --nodes=1
+#SBATCH --ntasks-per-node=4
+#SBATCH --ntasks-per-socket=1
+#SBATCH --cpus-per-task=64
+#SBATCH --partition=ghx4
+#SBATCH --time=00:10:00
+#SBATCH --job-name=quokka-1node
+#SBATCH --account=cvz-dtai-gh
+#SBATCH --gpus-per-node=4
+#SBATCH --gpu-bind=verbose,closest
+
+. scripts/delta_ai.profile
+
+srun build/src/problems/HydroBlast3D/test_hydro3d_blast tests/benchmark_unigrid_512.in

--- a/scripts/dtai-64node.submit
+++ b/scripts/dtai-64node.submit
@@ -1,0 +1,16 @@
+#!/bin/bash
+#SBATCH --mem=0
+#SBATCH --nodes=64
+#SBATCH --ntasks-per-node=4
+#SBATCH --ntasks-per-socket=1
+#SBATCH --cpus-per-task=64
+#SBATCH --partition=ghx4
+#SBATCH --time=00:10:00
+#SBATCH --job-name=quokka-64node
+#SBATCH --account=cvz-dtai-gh
+#SBATCH --gpus-per-node=4
+#SBATCH --gpu-bind=verbose,closest
+
+. scripts/delta_ai.profile
+
+srun build/src/problems/HydroBlast3D/test_hydro3d_blast tests/benchmark_unigrid_2048.in

--- a/scripts/dtai-8node.submit
+++ b/scripts/dtai-8node.submit
@@ -1,0 +1,16 @@
+#!/bin/bash
+#SBATCH --mem=0
+#SBATCH --nodes=8
+#SBATCH --ntasks-per-node=4
+#SBATCH --ntasks-per-socket=1
+#SBATCH --cpus-per-task=64
+#SBATCH --partition=ghx4
+#SBATCH --time=00:10:00
+#SBATCH --job-name=quokka-8node
+#SBATCH --account=cvz-dtai-gh
+#SBATCH --gpus-per-node=4
+#SBATCH --gpu-bind=verbose,closest
+
+. scripts/delta_ai.profile
+
+srun build/src/problems/HydroBlast3D/test_hydro3d_blast tests/benchmark_unigrid_1024.in

--- a/src/QuokkaSimulation.hpp
+++ b/src/QuokkaSimulation.hpp
@@ -190,6 +190,7 @@ template <typename problem_t> class QuokkaSimulation : public AMRSimulation<prob
 #if AMREX_SPACEDIM == 3
 	void createInitialCICParticles() override;
 	void createInitialCICRadParticles() override;
+	void createInitialStochasticStellarPopParticles() override;
 #endif // AMREX_SPACEDIM == 3
 	void advanceSingleTimestepAtLevel(int lev, amrex::Real time, amrex::Real dt_lev, int ncycle) override;
 	void computeBeforeTimestep() override;
@@ -582,6 +583,14 @@ template <typename problem_t> void QuokkaSimulation<problem_t>::createInitialCIC
 	// default empty implementation
 	// user should implement using problem-specific template specialization
 	// note: an implementation is only required if CICRad_particles are used
+}
+
+template <typename problem_t> void QuokkaSimulation<problem_t>::createInitialStochasticStellarPopParticles()
+{
+	// Optional implementation
+	// StochasticStellarPop particles are created on-the-fly from fluid cells. The user can optionally implement this function to create particles at the
+	// beginning of the simulation.
+	// note: an implementation is only effective if StochasticStellarPop_particles are used
 }
 
 #endif // AMREX_SPACEDIM == 3

--- a/src/QuokkaSimulation.hpp
+++ b/src/QuokkaSimulation.hpp
@@ -10,7 +10,15 @@
 /// timestepping, solving, and I/O of a simulation for radiation moments.
 
 #include <array>
+#if __has_include(<filesystem>)
 #include <filesystem>
+#elif __has_include(<experimental/filesystem>)
+#include <experimental/filesystem>
+namespace std
+{
+namespace filesystem = experimental::filesystem;
+}
+#endif
 #include <limits>
 #include <string>
 #include <tuple>

--- a/src/linear_advection/AdvectionSimulation.hpp
+++ b/src/linear_advection/AdvectionSimulation.hpp
@@ -69,6 +69,7 @@ template <typename problem_t> class AdvectionSimulation : public AMRSimulation<p
 #if AMREX_SPACEDIM == 3
 	void createInitialCICParticles() override;
 	void createInitialCICRadParticles() override;
+	void createInitialStochasticStellarPopParticles() override;
 #endif // AMREX_SPACEDIM == 3
 	void advanceSingleTimestepAtLevel(int lev, amrex::Real time, amrex::Real dt_lev, int /*ncycle*/) override;
 	void computeBeforeTimestep() override;
@@ -158,7 +159,7 @@ template <typename problem_t> void AdvectionSimulation<problem_t>::createInitial
 {
 	// default empty implementation
 	// user should implement using problem-specific template specialization
-	// note: an implementation is only required if particles are used
+	// note: an implementation is only required if Rad particles are used
 }
 
 #if AMREX_SPACEDIM == 3
@@ -167,16 +168,21 @@ template <typename problem_t> void AdvectionSimulation<problem_t>::createInitial
 {
 	// default empty implementation
 	// user should implement using problem-specific template specialization
-	// note: an implementation is only required if particles are used
+	// note: an implementation is only required if CIC particles are used
 }
 
 template <typename problem_t> void AdvectionSimulation<problem_t>::createInitialCICRadParticles()
 {
 	// default empty implementation
 	// user should implement using problem-specific template specialization
-	// note: an implementation is only required if particles are used
+	// note: an implementation is only required if CICRad particles are used
 }
 
+template <typename problem_t> void AdvectionSimulation<problem_t>::createInitialStochasticStellarPopParticles()
+{
+	// Optional implementation
+	// note: an implementation is only effective if StochasticStellarPop particles are used
+}
 #endif // AMREX_SPACEDIM == 3
 
 template <typename problem_t> void AdvectionSimulation<problem_t>::computeBeforeTimestep()

--- a/src/particles/PhysicsParticles.hpp
+++ b/src/particles/PhysicsParticles.hpp
@@ -554,6 +554,8 @@ template <typename problem_t> class PhysicsParticleRegister
 				return "CICRad_particles";
 			case ParticleType::Test:
 				return "Test_particles";
+			case ParticleType::StochasticStellarPop:
+				return "StochasticStellarPop_particles";
 			default:
 				return "Unknown_particles";
 		}
@@ -599,6 +601,9 @@ template <typename problem_t> class PhysicsParticleRegister
 		// Create the appropriate star particle descriptor based on the particle type
 		if (type == ParticleType::Test) {
 			descriptor = std::make_unique<StarParticleDescriptor<ContainerType, problem_t, ParticleType::Test>>(
+			    mass_idx, lum_idx, birth_time_idx, allows_creation, container, allows_destruction, evolution_stage_idx, hydro_interact);
+		} else if (type == ParticleType::StochasticStellarPop) {
+			descriptor = std::make_unique<StarParticleDescriptor<ContainerType, problem_t, ParticleType::StochasticStellarPop>>(
 			    mass_idx, lum_idx, birth_time_idx, allows_creation, container, allows_destruction, evolution_stage_idx, hydro_interact);
 		} else {
 			amrex::Abort("Unknown particle type for star particles");

--- a/src/particles/PhysicsParticles.hpp
+++ b/src/particles/PhysicsParticles.hpp
@@ -580,9 +580,6 @@ template <typename problem_t> class PhysicsParticleRegister
 		} else if (type == ParticleType::CICRad) {
 			descriptor = std::make_unique<PhysicsParticleDescriptor<ContainerType, problem_t, ParticleType::CICRad>>(
 			    mass_idx, lum_idx, birth_time_idx, allows_creation, container, allows_destruction, evolution_stage_idx, hydro_interact);
-		} else if (type == ParticleType::StellarPop) {
-			descriptor = std::make_unique<PhysicsParticleDescriptor<ContainerType, problem_t, ParticleType::StellarPop>>(
-			    mass_idx, lum_idx, birth_time_idx, allows_creation, container, allows_destruction, evolution_stage_idx, hydro_interact);
 		}
 #endif // AMREX_SPACEDIM == 3
 		else {

--- a/src/particles/particle_creation.hpp
+++ b/src/particles/particle_creation.hpp
@@ -1,6 +1,7 @@
 #ifndef PARTICLE_CREATION_HPP_
 #define PARTICLE_CREATION_HPP_
 
+#include "hydro/hydro_system.hpp"
 #include "particle_types.hpp"
 
 namespace quokka

--- a/src/particles/particle_creation.hpp
+++ b/src/particles/particle_creation.hpp
@@ -135,9 +135,9 @@ template <ParticleType particleType> struct ParticleCreationTraits {
 	}
 };
 
-// Specialization for StellarPop particles
-template <> struct ParticleCreationTraits<ParticleType::StellarPop> {
-	// Specialized nested ParticleChecker for StellarPop particles
+// Specialization for StochasticStellarPop particles
+template <> struct ParticleCreationTraits<ParticleType::StochasticStellarPop> {
+	// Specialized nested ParticleChecker for StochasticStellarPop particles
 	template <typename problem_t> struct ParticleChecker {
 		amrex::Real current_time;
 		amrex::Real dt;
@@ -160,7 +160,7 @@ template <> struct ParticleCreationTraits<ParticleType::StellarPop> {
 		}
 	};
 
-	// Specialized nested ParticleCreator for StellarPop particles
+	// Specialized nested ParticleCreator for StochasticStellarPop particles
 	template <typename problem_t> struct ParticleCreator {
 		int mass_idx;
 		int birth_time_index;
@@ -232,11 +232,11 @@ template <> struct ParticleCreationTraits<ParticleType::StellarPop> {
 				    int evolution_stage_index = -1, int birth_time_index = -1)
 	{
 		// Use the common implementation with our checker and creator types
-		ParticleCreationImpl::createParticlesImpl<problem_t, ContainerType, ParticleCreationTraits<ParticleType::StellarPop>::template ParticleChecker,
-							  ParticleCreationTraits<ParticleType::StellarPop>::template ParticleCreator>(container, mass_idx, state, lev, current_time, dt,
+		ParticleCreationImpl::createParticlesImpl<problem_t, ContainerType, ParticleCreationTraits<ParticleType::StochasticStellarPop>::template ParticleChecker,
+							  ParticleCreationTraits<ParticleType::StochasticStellarPop>::template ParticleCreator>(container, mass_idx, state, lev, current_time, dt,
 															       evolution_stage_index, birth_time_index);
 	}
-}; // ParticleCreationTraits<ParticleType::StellarPop>
+}; // ParticleCreationTraits<ParticleType::StochasticStellarPop>
 
 } // namespace quokka
 

--- a/src/particles/particle_types.hpp
+++ b/src/particles/particle_types.hpp
@@ -15,11 +15,12 @@ template <unsigned int position> constexpr auto bitflag() -> unsigned int { retu
 // To check if CIC particles are enabled:
 //   if (particle_switch & ParticleSwitch::CIC) { ... }
 enum class ParticleSwitch : unsigned int {
-	None = 0U,	       // No particles, = 0b0000
-	CIC = bitflag<1>(),    // Cloud-In-Cell (gravitating) particles, = 0b0001
-	Rad = bitflag<2>(),    // Radiation particles, = 0b0010
-	CICRad = bitflag<3>(), // Combined gravitating-radiating particles, = 0b0100
-	Test = bitflag<4>()    // Test particles with all features enabled, = 0b1000
+	None = 0U,			     // No particles, = 0b0000
+	CIC = bitflag<1>(),		     // Cloud-In-Cell (gravitating) particles, = 0b0001
+	Rad = bitflag<2>(),		     // Radiation particles, = 0b0010
+	CICRad = bitflag<3>(),		     // Combined gravitating-radiating particles, = 0b0100
+	StochasticStellarPop = bitflag<4>(), // Stellar population particles, = 0b1000
+	Test = bitflag<5>()		     // Test particles with all features enabled, = 0b1000
 };
 
 // Enable bitwise operations on the enum class
@@ -67,10 +68,11 @@ namespace quokka
 
 // Enum class to identify different particle types
 enum class ParticleType {
-	Rad,	// Radiation particles
-	CIC,	// Gravitating particles
-	CICRad, // Gravitating radiation particles
-	Test	// Test particles with all features enabled
+	Rad,		      // Radiation particles
+	CIC,		      // Gravitating particles
+	CICRad,		      // Gravitating radiation particles
+	StochasticStellarPop, // Stellar population particles
+	Test		      // Test particles with all features enabled
 };
 
 // Global particle parameters
@@ -152,7 +154,7 @@ constexpr int CICRadParticleRealComps = []() constexpr {
 template <typename problem_t> using CICRadParticleContainer = amrex::AmrParticleContainer<CICRadParticleRealComps<problem_t>>;
 template <typename problem_t> using CICRadParticleIterator = amrex::ParIter<CICRadParticleRealComps<problem_t>>;
 
-//-------------------- Test particles --------------------
+//-------------------- Stellar evolution stage enum --------------------
 
 // Enum for StellarEvolution particle stage
 enum class StellarEvolutionStage {
@@ -160,6 +162,42 @@ enum class StellarEvolutionStage {
 	SNProgenitor, // Supernova progenitor stage
 	SNRemnant     // Supernova remnant stage
 };
+
+//-------------------- Stellar population particles --------------------
+
+// Indices for stellar population particles (StochasticStellarPop_particles), mass + 3 velocity components + fate + luminosity
+enum StochasticStellarPopParticleDataIdx {
+	StochasticStellarPopParticleMassIdx = 0,  // Mass of the particle
+	StochasticStellarPopParticleVxIdx,	  // Velocity in x direction
+	StochasticStellarPopParticleVyIdx,	  // Velocity in y direction
+	StochasticStellarPopParticleVzIdx,	  // Velocity in z direction
+	StochasticStellarPopParticleBirthTimeIdx, // Time when particle becomes active
+	StochasticStellarPopParticleLumIdx	  // Base index for luminosity components
+};
+
+constexpr int StochasticStellarPopParticleStageIdx = 0; // Evolution stage of the particle, index in the integer components
+
+// Number of real components for StochasticStellarPop_particles, mass + 3 velocity components + luminosity
+template <typename problem_t>
+constexpr int StochasticStellarPopParticleRealComps = []() constexpr {
+	if constexpr (Physics_Traits<problem_t>::is_hydro_enabled && Physics_Traits<problem_t>::is_radiation_enabled) {
+		return 5 + Physics_Traits<problem_t>::nGroups; // mass, vx, vy, vz, birth_time, lum[nGroups]
+	} else {
+		return 5; // mass, vx, vy, vz, birth_time
+	}
+}();
+
+// Number of integer components for StochasticStellarPop_particles
+constexpr int StochasticStellarPopParticleIntComps = 1; // fate
+
+// Type definitions for StochasticStellarPop_particles container and iterator
+template <typename problem_t>
+using StochasticStellarPopParticleContainer =
+    amrex::AmrParticleContainer<StochasticStellarPopParticleRealComps<problem_t>, StochasticStellarPopParticleIntComps>;
+template <typename problem_t>
+using StochasticStellarPopParticleIterator = amrex::ParIter<StochasticStellarPopParticleRealComps<problem_t>, StochasticStellarPopParticleIntComps>;
+
+//-------------------- Test particles --------------------
 
 // Indices for test particles (Test_particles)
 enum TestParticleDataIdx {
@@ -173,13 +211,13 @@ enum TestParticleDataIdx {
 
 constexpr int TestParticleStageIdx = 0; // Evolution stage of the particle, index in the integer components
 
-// Number of real components for StellarPop_particles, mass + 3 velocity components + luminosity
+// Number of real components for StochasticStellarPop_particles, mass + 3 velocity components + luminosity
 template <typename problem_t>
 constexpr int TestParticleRealComps = []() constexpr {
 	if constexpr (Physics_Traits<problem_t>::is_hydro_enabled && Physics_Traits<problem_t>::is_radiation_enabled) {
-		return 6 + Physics_Traits<problem_t>::nGroups; // mass, vx, vy, vz, birth_time, stage, lum[nGroups]
+		return 5 + Physics_Traits<problem_t>::nGroups; // mass, vx, vy, vz, birth_time, stage, lum[nGroups]
 	} else {
-		return 6; // mass, vx, vy, vz, birth_time, stage
+		return 5; // mass, vx, vy, vz, birth_time, stage
 	}
 }();
 
@@ -205,6 +243,13 @@ inline auto get_units_data() -> const auto &
 	       {"vz", {0, 1, -1, 0}},
 	       {"birth_time", {0, 0, 1, 0}},
 	       {"death_time", {0, 0, 1, 0}},
+	       {"luminosity", {-1, 2, -3, 0}}}}},
+	    {ParticleType::StochasticStellarPop,
+	     {{{"mass", {1, 0, 0, 0}},
+	       {"vx", {0, 1, -1, 0}},
+	       {"vy", {0, 1, -1, 0}},
+	       {"vz", {0, 1, -1, 0}},
+	       {"birth_time", {0, 0, 1, 0}},
 	       {"luminosity", {-1, 2, -3, 0}}}}},
 	    {ParticleType::Test,
 	     {{{"mass", {1, 0, 0, 0}},

--- a/src/particles/particle_types.hpp
+++ b/src/particles/particle_types.hpp
@@ -171,7 +171,8 @@ enum StochasticStellarPopParticleDataIdx {
 	StochasticStellarPopParticleVxIdx,	  // Velocity in x direction
 	StochasticStellarPopParticleVyIdx,	  // Velocity in y direction
 	StochasticStellarPopParticleVzIdx,	  // Velocity in z direction
-	StochasticStellarPopParticleBirthTimeIdx, // Time when particle becomes active
+	StochasticStellarPopParticleBirthTimeIdx, // Time when a particle is created
+	StochasticStellarPopParticleDeathTimeIdx, // Time when a particle is destroyed/explodes as a SN
 	StochasticStellarPopParticleLumIdx	  // Base index for luminosity components
 };
 
@@ -181,9 +182,9 @@ constexpr int StochasticStellarPopParticleStageIdx = 0; // Evolution stage of th
 template <typename problem_t>
 constexpr int StochasticStellarPopParticleRealComps = []() constexpr {
 	if constexpr (Physics_Traits<problem_t>::is_hydro_enabled && Physics_Traits<problem_t>::is_radiation_enabled) {
-		return 5 + Physics_Traits<problem_t>::nGroups; // mass, vx, vy, vz, birth_time, lum[nGroups]
+		return 6 + Physics_Traits<problem_t>::nGroups; // mass, vx, vy, vz, birth_time, lum[nGroups]
 	} else {
-		return 5; // mass, vx, vy, vz, birth_time
+		return 6; // mass, vx, vy, vz, birth_time
 	}
 }();
 

--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -234,6 +234,7 @@ template <typename problem_t> class AMRSimulation : public amrex::AmrCore
 #if AMREX_SPACEDIM == 3
 	virtual void createInitialCICParticles() = 0;
 	virtual void createInitialCICRadParticles() = 0;
+	virtual void createInitialStochasticStellarPopParticles() = 0;
 	// Test particles have integer components, and InitFromAsciiFile does not support integer components, so we do not allow creating them at the start
 	// of the simulation
 #endif // AMREX_SPACEDIM == 3
@@ -471,6 +472,7 @@ template <typename problem_t> class AMRSimulation : public amrex::AmrCore
 #if AMREX_SPACEDIM == 3
 	std::unique_ptr<quokka::CICParticleContainer> CICParticles;
 	std::unique_ptr<quokka::CICRadParticleContainer<problem_t>> CICRadParticles;
+	std::unique_ptr<quokka::StochasticStellarPopParticleContainer<problem_t>> StochasticStellarPopParticles;
 	std::unique_ptr<quokka::TestParticleContainer<problem_t>> TestParticles;
 #endif // AMREX_SPACEDIM == 3
 #endif
@@ -2193,6 +2195,24 @@ template <typename problem_t> void AMRSimulation<problem_t>::InitPhyParticles()
 		createInitialCICRadParticles();
 	}
 
+	if constexpr (Particle_Traits<problem_t>::particle_switch & ParticleSwitch::StochasticStellarPop) {
+		AMREX_ASSERT(StochasticStellarPopParticles == nullptr);
+
+		// Create particle container
+		StochasticStellarPopParticles = std::make_unique<quokka::StochasticStellarPopParticleContainer<problem_t>>(this);
+		StochasticStellarPopParticles->SetVerbose(0);
+
+		// Register with particle register - StochasticStellarPop particles allow creation
+		const bool StochasticStellarPop_allows_destruction = false;
+		particleRegister_.registerStarParticleType(StochasticStellarPopParticles.get(), quokka::ParticleType::StochasticStellarPop,
+							   quokka::StochasticStellarPopParticleMassIdx, quokka::StochasticStellarPopParticleLumIdx,
+							   quokka::StochasticStellarPopParticleBirthTimeIdx, true, StochasticStellarPop_allows_destruction,
+							   quokka::StochasticStellarPopParticleStageIdx, true);
+
+		// Initialize particles through derived class
+		createInitialStochasticStellarPopParticles();
+	}
+
 	if constexpr (Particle_Traits<problem_t>::particle_switch & ParticleSwitch::Test) {
 		AMREX_ASSERT(TestParticles == nullptr);
 
@@ -2960,6 +2980,17 @@ template <typename problem_t> void AMRSimulation<problem_t>::ReadCheckpointFile(
 		particleRegister_.registerParticleType(CICRadParticles.get(), quokka::ParticleType::CICRad, quokka::CICRadParticleMassIdx,
 						       quokka::CICRadParticleLumIdx, false, quokka::CICRadParticleBirthTimeIdx);
 		CICRadParticles->Restart(restart_chkfile, particleRegister_.getParticleTypeName(quokka::ParticleType::CICRad));
+	}
+
+	if constexpr (Particle_Traits<problem_t>::particle_switch & ParticleSwitch::StochasticStellarPop) {
+		AMREX_ASSERT(StochasticStellarPopParticles == nullptr);
+		const bool StochasticStellarPop_allows_destruction = false;
+		StochasticStellarPopParticles = std::make_unique<quokka::StochasticStellarPopParticleContainer<problem_t>>(this);
+		particleRegister_.registerStarParticleType(StochasticStellarPopParticles.get(), quokka::ParticleType::StochasticStellarPop,
+							   quokka::StochasticStellarPopParticleMassIdx, quokka::StochasticStellarPopParticleLumIdx,
+							   quokka::StochasticStellarPopParticleBirthTimeIdx, true, StochasticStellarPop_allows_destruction,
+							   quokka::StochasticStellarPopParticleStageIdx, true);
+		StochasticStellarPopParticles->Restart(restart_chkfile, particleRegister_.getParticleTypeName(quokka::ParticleType::StochasticStellarPop));
 	}
 
 	if constexpr (Particle_Traits<problem_t>::particle_switch & ParticleSwitch::Test) {

--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -100,6 +100,9 @@ using namespace conduit;
 using namespace ascent;
 #endif
 
+// Quokka version string to be stored in metadata. This is used in post-processing tools like YT to do version checks.
+static constexpr auto QUOKKA_VERSION = "25.03";
+
 enum class ParticleStep { BeforePoissonSolve, AfterPoissonSolve };
 
 using variant_t = std::variant<amrex::Real, std::string>;
@@ -559,6 +562,9 @@ template <typename problem_t> void AMRSimulation<problem_t>::initialize()
 			amrex::Abort("Grids not properly nested!");
 		}
 	}
+
+	// add Quokka version to metadata
+	simulationMetadata_["quokka_version"] = QUOKKA_VERSION;
 
 	// add git commit to metadata
 	simulationMetadata_["git_hash_quokka"] = getGitHashForQuokka();

--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -10,6 +10,7 @@
 /// timestepping, solving, and I/O of a simulation.
 
 // c++ headers
+#include <cfenv>
 #include <cmath>
 #include <cstdint>
 #include <cstdio>
@@ -2551,6 +2552,9 @@ template <typename problem_t> void AMRSimulation<problem_t>::WriteMetadataFile(s
 
 template <typename problem_t> void AMRSimulation<problem_t>::ReadMetadataFile(std::string const &chkfilename)
 {
+	fenv_t orig_feenv;
+	feholdexcept(&orig_feenv); // disable FPE for YAML reading
+
 	// read metadata file in on all ranks (needed when restarting from checkpoint)
 	const std::string MetadataFileName(chkfilename + "/metadata.yaml");
 
@@ -2573,6 +2577,8 @@ template <typename problem_t> void AMRSimulation<problem_t>::ReadMetadataFile(st
 			amrex::Print() << fmt::format("\t{} has unknown type! skipping this entry.\n", key);
 		}
 	}
+
+	fesetenv(&orig_feenv); // restore FPE
 }
 
 template <typename problem_t> void AMRSimulation<problem_t>::WriteProjectionPlotfile() const


### PR DESCRIPTION
### Description

Previously, we have a new particle type called StellarPop that only exist in the aditivijayan/quokka/StellarPop branch. Every time we merge in the development branch, we have to deal with conflicts. This is inconvenient. So, I updated the development branch to include the StellarPop particle type (now renamed to StochasticStellarPop, recommended by Mark): https://github.com/quokka-astro/quokka/pull/954 . This PR merges in that update. After this PR, the only difference from this StellarPop branch and the development branch is the Specialization of ParticleCreationTraits for StochasticStellarPop particles in particle_creation.hpp . This makes future update much easier. 

### Related issues
Are there any GitHub issues that are fixed by this pull request? Add a link to them here.

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [x] I have added a description (see above).
- [x] I have added a link to any related issues (if applicable; see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [ ] *(For quokka-astro org members)* I have manually triggered the GPU tests with the magic comment `/azp run`.
